### PR TITLE
Switching over to drush-alias.amazeeio.cloud

### DIFF
--- a/drush/aliases.drushrc.php
+++ b/drush/aliases.drushrc.php
@@ -2,6 +2,13 @@
 // Don't change anything here, it's magic!
 global $aliases_stub;
 if (empty($aliases_stub)) {
-  $aliases_stub = file_get_contents('https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_URL, 'https://drush-alias.amazeeio.cloud/aliases.drushrc.php.stub');
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    $aliases_stub = curl_exec($ch);
+    curl_close($ch);
 }
 eval($aliases_stub);


### PR DESCRIPTION
I've updated this to match the updated code in the amazeeio/drupal-setting-files repository (https://github.com/amazeeio/drupal-setting-files/blob/master/Drupal7/drush/aliases.drushrc.php)